### PR TITLE
Add 404 Media

### DIFF
--- a/rssfeeds.json
+++ b/rssfeeds.json
@@ -108,6 +108,12 @@
         "redirectLinks": false
     },
     {
+        "url": "https://www.404media.co/rss",
+        "outlet": "404 Media",
+        "delicateURLs": false,
+        "redirectLinks": false
+    },
+    {
         "url": "http://feedshack.biz/ap_rss.xml",
         "outlet": "Associated Press",
         "delicateURLs": false,


### PR DESCRIPTION
An independent media outlet by former writers of VICE's Motherboard, including a focus on FOIA reporting: https://www.404media.co/welcome-to-404-media/

Example FOIA-based article: https://www.404media.co/clear-as-mud-internal-emails-show-superintendents-struggling-to-comply-with-desantis-law/

Disclosure: I'm a subscriber/backer of 404 Media.